### PR TITLE
Simplified Audio with Fluidsynth/MIDI

### DIFF
--- a/neuros/data_processor.py
+++ b/neuros/data_processor.py
@@ -1,12 +1,23 @@
 import numpy as np
 from brainflow.data_filter import DataFilter, FilterTypes, DetrendOperations
-from dataclasses import dataclass
 from typing import NamedTuple, Dict
 
 
 def extract_band_power(data: np.ndarray, sampling_rate: int,
                        low_freq: float, high_freq: float) -> float:
-    """Extract power in a specific frequency band from signal"""
+    """
+    Extract band power from EEG data.
+
+    Args:
+        data: 1D numpy array of samples.
+        sampling_rate: Sampling rate in Hz.
+        low_freq: Lower frequency bound.
+        high_freq: Upper frequency bound.
+
+    Returns:
+        Band power as a float.
+    """
+
     filtered = data.copy()
     DataFilter.detrend(filtered, DetrendOperations.CONSTANT.value)
     DataFilter.perform_bandpass(

--- a/neuros/data_processor.py
+++ b/neuros/data_processor.py
@@ -73,15 +73,3 @@ def process_window(window: np.ndarray, sampling_rate: int) -> list[float]:
     """
     return [process_channel(window[i], sampling_rate) for i in range(window.shape[0])]
 
-
-def map_to_midi(alpha_ratio: float) -> int:
-    """
-    Map alpha/total power ratio (0-1) to MIDI velocity (0-127).
-
-    Args:
-        alpha_ratio: Alpha/total power ratio as a float.
-
-    Returns:
-        MIDI velocity as an integer.
-    """
-    return int(np.clip(alpha_ratio * 127, 0, 127))

--- a/neuros/data_streamer.py
+++ b/neuros/data_streamer.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass
-from typing import Iterator, Optional
+from typing import Iterator, Optional, Tuple
 import numpy as np
 from contextlib import contextmanager
 from brainflow.board_shim import BoardShim, BrainFlowInputParams, BoardIds
@@ -11,12 +11,29 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class WindowConfig:
-    """Configuration for data windowing"""
-    window_ms: float  # Window size in milliseconds
-    overlap_ms: float = 0.0  # Overlap between windows
+    """Configuration for EEG data windowing.
 
-    def __post_init__(self):
-        """Validate configuration after initialization"""
+    This class handles configuration for windowing continuous EEG data,
+    supporting overlapping windows for analysis.
+
+    Attributes:
+        window_ms: Window size in milliseconds.
+        overlap_ms: Overlap between consecutive windows in milliseconds.
+            Defaults to 0.0 (no overlap).
+
+    Raises:
+        ValueError: If window_ms is not positive, overlap_ms is negative,
+            or overlap_ms is greater than or equal to window_ms.
+    """
+    window_ms: float
+    overlap_ms: float = 0.0
+
+    def __post_init__(self) -> None:
+        """Validate window configuration parameters.
+
+        Raises:
+            ValueError: If window parameters are invalid.
+        """
         if self.window_ms <= 0:
             raise ValueError("Window size must be positive")
         if self.overlap_ms >= self.window_ms:
@@ -24,29 +41,42 @@ class WindowConfig:
         if self.overlap_ms < 0:
             raise ValueError("Overlap must be non-negative")
 
-    def to_samples(self, sample_rate: int) -> tuple[int, int]:
-        """Convert time-based config to sample counts"""
+    def convert_to_samples(self, sample_rate: int) -> Tuple[int, int]:
+        """Convert time-based configuration to sample counts.
+
+        Args:
+            sample_rate: Sampling rate in Hz.
+
+        Returns:
+            Tuple containing (window_samples, overlap_samples).
+
+        Raises:
+            ValueError: If resulting overlap is greater than or equal to window size.
+        """
         window_samples = int(sample_rate * self.window_ms / 1000)
         overlap_samples = int(sample_rate * self.overlap_ms / 1000)
         if overlap_samples >= window_samples:
             raise ValueError("Overlap must be less than window size")
         return window_samples, overlap_samples
 
+
 @contextmanager
-def board_stream(board_id: int = BoardIds.SYNTHETIC_BOARD,
-                 params: Optional[BrainFlowInputParams] = None) -> BoardShim:
-    """
-    Create and manage a board connection.
+def create_board_stream(board_id: int = BoardIds.SYNTHETIC_BOARD,
+                       params: Optional[BrainFlowInputParams] = None) -> Iterator[BoardShim]:
+    """Create and manage a BrainFlow board connection.
+
+    Context manager that handles board initialization, streaming, and cleanup.
 
     Args:
-        board_id: BrainFlow board identifier
-        params: Optional board parameters
+        board_id: BrainFlow board identifier. Defaults to synthetic board.
+        params: Optional board parameters. If None, uses default parameters.
 
     Yields:
-        Connected BoardShim instance
+        Connected BoardShim instance ready for data streaming.
 
     Raises:
-        BrainFlowError: If board initialization or streaming fails
+        BrainFlowError: If board initialization or streaming fails.
+        Exception: For other unexpected errors during board operation.
     """
     board = BoardShim(board_id, params or BrainFlowInputParams())
     try:
@@ -66,22 +96,31 @@ def board_stream(board_id: int = BoardIds.SYNTHETIC_BOARD,
 
 
 def stream_windows(board: BoardShim, config: WindowConfig) -> Iterator[np.ndarray]:
-    """
-    Generate windows of EEG data from board stream.
+    """Generate windows of EEG data from a board stream.
 
-    This generator yields windows of data continuously from the board stream.
-    Each window contains data from all EEG channels and can overlap with previous windows.
+    Creates a generator that continuously yields windows of EEG data from
+    the board stream. Windows can overlap based on the configuration.
 
     Args:
-        board: Connected and streaming BoardShim instance
-        config: Window configuration for size and overlap
+        board: Connected and streaming BoardShim instance.
+        config: Configuration specifying window size and overlap.
 
     Yields:
-        Windows of data as numpy arrays with shape (channels, samples)
+        np.ndarray: Windows of data with shape (channels, samples).
+            Each window contains data from all EEG channels.
+
+    Raises:
+        GeneratorExit: When streaming is stopped.
+        Exception: For errors during data acquisition.
+
+    Notes:
+        - Uses a 1024-sample buffer for data acquisition
+        - Automatically handles partial data chunks
+        - Thread-safe for concurrent access
     """
     # Convert ms-based config to samples
     sample_rate = board.get_sampling_rate(board_id=board.board_id)
-    window_samples, overlap_samples = config.to_samples(sample_rate)
+    window_samples, overlap_samples = config.convert_to_samples(sample_rate)
     needed = window_samples - overlap_samples
 
     # Get EEG channel information

--- a/neuros/main.py
+++ b/neuros/main.py
@@ -8,30 +8,49 @@ from tone_generator import ToneGenerator
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG)
 
+
 def main() -> None:
-    """Demonstrate EEG data streaming with a simple tone generator."""
+    """
+    Main function for EEG neurofeedback using Brainflow's synthetic board
+    for the data source, and FluidSynth for audio output.
+    This version: Uses synthetic board's first channel (5Hz sine wave) for testing.
+    """
+    # Configure window parameters based on synthetic board characteristics
     config = WindowConfig(window_ms=550.0, overlap_ms=225.0)
 
-    # Initialize ToneGenerator
-    tone_generator = ToneGenerator()
+    tone = ToneGenerator()
+
+    # Audio feedback parameters
+    base_amplitude = 0.3  # Minimum amplitude
+    amplitude_boost = 2  # Additional amplitude range
+
 
     try:
+        # Initialize board and start streaming
         with create_board_stream(board_id=BoardIds.SYNTHETIC_BOARD) as board:
             sample_rate = board.get_sampling_rate(board_id=board.board_id)
             logger.info(f"Board ready - sample rate: {sample_rate} Hz")
             logger.info("Press Ctrl+C to stop...")
 
-            tone_generator.play()  # Start playing the tone
-
+            # Process streaming windows
             for window in stream_windows(board, config):
-                # Extract alpha/total ratio for channel 1
-                ratios = process_window(window, sample_rate)
-                channel_1_ratio = ratios[0]  # Assuming channel 1 is index 0
+                # Get first channel data
+                channel_alpha = window[0:1]  # Just first channel
 
-                # Update the tone volume (Only channel 1 for now)
-                tone_generator.set_volume(channel_1_ratio)
+                # Process window and get alpha ratio
+                ratios = process_window(channel_alpha, sample_rate)
+                channel_1_ratio = ratios[0]
 
-                time.sleep(0.1)  # Adjust for desired responsiveness
+                # Convert ratio to amplitude
+                amplitude = min(base_amplitude + (channel_1_ratio * amplitude_boost), 1.0)
+
+                # Update tone amplitude
+                tone.set_amplitude(amplitude)
+
+                logger.debug(f"Alpha ratio: {channel_1_ratio:.3f}, Amplitude: {amplitude:.3f}")
+
+                # Sleep for a while
+                time.sleep(config.window_ms / 1000)
 
     except KeyboardInterrupt:
         logger.info("\nStopped by user")
@@ -39,7 +58,8 @@ def main() -> None:
         logger.error(f"\nError: {e}")
         raise
     finally:
-        tone_generator.stop()  # Stop tone and clean up
+        logger.info("Cleaning up...")
+        tone.cleanup()
 
 
 if __name__ == "__main__":

--- a/neuros/main.py
+++ b/neuros/main.py
@@ -2,55 +2,44 @@ import logging
 import time
 from brainflow.board_shim import BoardIds
 from neuros.data_streamer import WindowConfig, create_board_stream, stream_windows
+from neuros.data_processor import process_window
+from tone_generator import ToneGenerator
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG)
 
-
 def main() -> None:
-    """Demonstrate EEG data streaming with synthetic board.
-
-    This example shows basic usage of the data streaming components:
-    - Creates a 550ms window configuration with 225ms overlap
-    - Connects to BrainFlow's synthetic board
-    - Streams windowed data from first 3 EEG channels
-    - Processes windows until interrupted
-
-    The synthetic board provides test signals:
-    - Channel 1: 5 Hz sine wave (below alpha band)
-    - Channel 2: 10 Hz sine wave (within alpha band)
-    - Channel 3: 15 Hz sine wave (above alpha band)
-
-    Press Ctrl+C to stop the stream.
-
-    Raises:
-        KeyboardInterrupt: When user stops the program
-        Exception: For other unexpected errors during execution
-    """
-    # Configure window parameters based on synthetic board characteristics
+    """Demonstrate EEG data streaming with a simple tone generator."""
     config = WindowConfig(window_ms=550.0, overlap_ms=225.0)
 
+    # Initialize ToneGenerator
+    tone_generator = ToneGenerator()
+
     try:
-        # Initialize board and start streaming
         with create_board_stream(board_id=BoardIds.SYNTHETIC_BOARD) as board:
             sample_rate = board.get_sampling_rate(board_id=board.board_id)
             logger.info(f"Board ready - sample rate: {sample_rate} Hz")
             logger.info("Press Ctrl+C to stop...")
 
-            # Process streaming windows
-            for window in stream_windows(board, config):
-                # Extract first three channels (known test signals)
-                window = window[:3]
-                logger.debug(f"Window shape: {window.shape}")
+            tone_generator.play()  # Start playing the tone
 
-                # Prevent CPU overload in this example
-                time.sleep(0.01)
+            for window in stream_windows(board, config):
+                # Extract alpha/total ratio for channel 1
+                ratios = process_window(window, sample_rate)
+                channel_1_ratio = ratios[0]  # Assuming channel 1 is index 0
+
+                # Update the tone volume (Only channel 1 for now)
+                tone_generator.set_volume(channel_1_ratio)
+
+                time.sleep(0.1)  # Adjust for desired responsiveness
 
     except KeyboardInterrupt:
         logger.info("\nStopped by user")
     except Exception as e:
         logger.error(f"\nError: {e}")
         raise
+    finally:
+        tone_generator.stop()  # Stop tone and clean up
 
 
 if __name__ == "__main__":

--- a/neuros/main.py
+++ b/neuros/main.py
@@ -1,28 +1,49 @@
 import logging
 import time
 from brainflow.board_shim import BoardIds
-from neuros.window_stream import WindowConfig, board_stream, stream_windows
+from neuros.data_streamer import WindowConfig, create_board_stream, stream_windows
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.DEBUG)
 
 
 def main() -> None:
-    """Example usage demonstrating window streaming with synthetic board"""
+    """Demonstrate EEG data streaming with synthetic board.
+
+    This example shows basic usage of the data streaming components:
+    - Creates a 550ms window configuration with 225ms overlap
+    - Connects to BrainFlow's synthetic board
+    - Streams windowed data from first 3 EEG channels
+    - Processes windows until interrupted
+
+    The synthetic board provides test signals:
+    - Channel 1: 5 Hz sine wave (below alpha band)
+    - Channel 2: 10 Hz sine wave (within alpha band)
+    - Channel 3: 15 Hz sine wave (above alpha band)
+
+    Press Ctrl+C to stop the stream.
+
+    Raises:
+        KeyboardInterrupt: When user stops the program
+        Exception: For other unexpected errors during execution
+    """
+    # Configure window parameters based on synthetic board characteristics
     config = WindowConfig(window_ms=550.0, overlap_ms=225.0)
 
     try:
-        with board_stream(board_id=BoardIds.SYNTHETIC_BOARD) as board:
+        # Initialize board and start streaming
+        with create_board_stream(board_id=BoardIds.SYNTHETIC_BOARD) as board:
             sample_rate = board.get_sampling_rate(board_id=board.board_id)
             logger.info(f"Board ready - sample rate: {sample_rate} Hz")
             logger.info("Press Ctrl+C to stop...")
 
+            # Process streaming windows
             for window in stream_windows(board, config):
-                # Get data just for first 3 channels
+                # Extract first three channels (known test signals)
                 window = window[:3]
                 logger.debug(f"Window shape: {window.shape}")
 
-                # Small delay to prevent CPU overload
+                # Prevent CPU overload in this example
                 time.sleep(0.01)
 
     except KeyboardInterrupt:

--- a/neuros/tone_generator.py
+++ b/neuros/tone_generator.py
@@ -1,0 +1,27 @@
+from fluidsynth import Synth
+
+SOUNDFONT_PATH = "/usr/share/sounds/sf2/FluidR3_GM.sf2"
+
+
+class ToneGenerator:
+    def __init__(self, midi_note=69):
+        """Initialize the tone generator with a default MIDI note."""
+        self.midi_note = midi_note
+        self.synth = Synth()
+        self.synth.start(driver="alsa")  # Use ALSA or the default driver
+        self.soundfont_id = self.synth.sfload(SOUNDFONT_PATH)
+        self.synth.program_select(0, self.soundfont_id, 0, 0)  # Bank 0, Preset 0
+
+    def set_volume(self, intensity):
+        """Map intensity (0-1) to MIDI velocity (0-127) and adjust volume."""
+        velocity = int(max(0, min(127, intensity * 127)))
+        self.synth.cc(0, 7, velocity)  # MIDI Control Change: Volume (CC 7)
+
+    def play(self):
+        """Play the note."""
+        self.synth.noteon(0, self.midi_note, 100)  # Channel 0, Velocity 100
+
+    def stop(self):
+        """Stop the note and clean up resources."""
+        self.synth.noteoff(0, self.midi_note)
+        self.synth.delete()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy~=2.2.1
+brainflow~=5.15.0
+pyfluidsynth~=1.3.4

--- a/tests/test_process_data.py
+++ b/tests/test_process_data.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from neuros.process_data import (
+from neuros.data_processor import (
     extract_band_power, extract_all_bands,
     compute_band_ratios, process_window, PowerMetrics
 )

--- a/tests/test_process_synthetic_data.py
+++ b/tests/test_process_synthetic_data.py
@@ -1,8 +1,8 @@
 import pytest
 import numpy as np
 from brainflow.board_shim import BoardIds
-from neuros.window_stream import WindowConfig, board_stream, stream_windows
-from neuros.process_data import process_window
+from neuros.data_streamer import WindowConfig, board_stream, stream_windows
+from neuros.data_processor import process_window
 
 
 def test_synthetic_alpha_ratios():


### PR DESCRIPTION
In this branch, the audio functionality is refactored. Instead of generating tones, balancing them, mapping them to speakers and playing them, we will let fluidsynth do all of the work.

Note: Fluidsynth has a python package pyfluidsynth, but it also requires that fluidsynth is installed on the host OS. There is a standard location for the default instrument set ("soundfont") that varies by distro. The assumed distro here will be Ubuntu 24.04.1 LTS. We also assume surround sound (7.1). Support for other OSs, distros, or speaker configurations may be added in a future update.